### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ $(qemu): $(qemu_srcdir)
 	mkdir -p $(dir $@)
 	cd $(qemu_wrkdir) && $</configure \
 		--prefix=$(dir $(abspath $(dir $@))) \
+		--python=python2 \
 		--target-list=riscv64-softmmu
 	$(MAKE) -C $(qemu_wrkdir)
 	$(MAKE) -C $(qemu_wrkdir) install

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ $(toolchain_dest)/bin/$(target)-gcc: $(toolchain_srcdir)
 		--prefix=$(toolchain_dest) \
 		--with-arch=$(ISA) \
 		--with-abi=$(ABI) \
+		--with-guile=guile-2.0 \
 		--enable-linux
 	$(MAKE) -C $(toolchain_wrkdir)
 	sed 's/^#define LINUX_VERSION_CODE.*/#define LINUX_VERSION_CODE 263682/' -i $(toolchain_dest)/sysroot/usr/include/linux/version.h


### PR DESCRIPTION
freedom-u-sdk is unable to build under Arch Linux with default guile-2.2 and python-3.6 package versions. So we need to specify older package versions.