### PR TITLE
adding openocd.cfg file for freedom unleashed board.

### DIFF
--- a/bsp/env/freedom-u500-unleashed/openocd.cfg
+++ b/bsp/env/freedom-u500-unleashed/openocd.cfg
@@ -1,0 +1,24 @@
+adapter_khz     10000
+
+interface ftdi
+ftdi_device_desc "Dual RS232-HS"
+ftdi_vid_pid 0x0403 0x6010
+
+ftdi_layout_init 0x0008 0x001b
+ftdi_layout_signal nSRST -oe 0x0020 -data 0x0020
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
+$_TARGETNAME configure -work-area-phys 0x80000000 -work-area-size 10000 -work-area-backup 1
+
+flash bank onboard_spi_flash fespi 0x20000000 0 0 0 $_TARGETNAME 0x10040000
+init 
+halt
+
+# Uncomment this if you want to be able to clobber your SPI Flash, which
+# probably you don't since you can do it through Linux
+  
+# flash protect 0 0 last off


### PR DESCRIPTION
@mwachs5 found the openocd.cfg file we used during bring-up and @sifivedl requested we integrate it into freedom-u-sdk as everyone's already looking there for info re: the unleashed board.