### PR TITLE
Add CROSS_COMPILE to the root Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ $(buildroot_initramfs_wrkdir)/.config: $(buildroot_srcdir)
 	rm -rf $(dir $@)
 	mkdir -p $(dir $@)
 	cp $(buildroot_initramfs_config) $@
-	$(MAKE) -C $< RISCV=$(RISCV) PATH=$(PATH) O=$(buildroot_initramfs_wrkdir) olddefconfig
+	$(MAKE) -C $< RISCV=$(RISCV) PATH=$(PATH) O=$(buildroot_initramfs_wrkdir) olddefconfig CROSS_COMPILE=riscv64-unknown-linux-gnu-
 
 $(buildroot_initramfs_tar): $(buildroot_srcdir) $(buildroot_initramfs_wrkdir)/.config $(RISCV)/bin/$(target)-gcc $(buildroot_initramfs_config)
 	$(MAKE) -C $< RISCV=$(RISCV) PATH=$(PATH) O=$(buildroot_initramfs_wrkdir)
@@ -136,6 +136,7 @@ $(vmlinux): $(linux_srcdir) $(linux_wrkdir)/.config $(buildroot_initramfs_sysroo
 		CONFIG_INITRAMFS_SOURCE="$(confdir)/initramfs.txt $(buildroot_initramfs_sysroot)" \
 		CONFIG_INITRAMFS_ROOT_UID=$(shell id -u) \
 		CONFIG_INITRAMFS_ROOT_GID=$(shell id -g) \
+		CROSS_COMPILE=riscv64-unknown-linux-gnu- \
 		ARCH=riscv \
 		vmlinux
 


### PR DESCRIPTION
commit f1089c92 (kbuild: remove CONFIG_CROSS_COMPILE support)
removed CROSS_COMPILE support from kernel makefile.

Add it to the freedom-u-sdk makefile in order to compile freedom-u-sdk
just by doing make. The other alternative is to pass CROSS_COMPILE
option everytime along with make which is little cumbersome.

Signed-off-by: Atish Patra <atish.patra@wdc.com>