### PR TITLE
Unmatched: enable initramfs framework

### DIFF
--- a/recipes-core/initrdscripts/initramfs-framework/nbdrootfs
+++ b/recipes-core/initrdscripts/initramfs-framework/nbdrootfs
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+nbdrootfs_enabled() {
+	if [ ${bootparam_root} != "/dev/nbd0" ] || [ -z ${bootparam_nbdroot} ]; then
+		return 1
+	fi
+	return 0
+}
+
+nbdrootfs_run() {
+	local nbd_opts
+	local location
+	local server_ip
+	local iptype
+
+	# ip=dhcp root=/dev/nbd0 rw nbdroot=10.0.2.2:foo nbdport=10809 console=ttySIF0,115200 earlycon=sbi
+#	bootparam_nbdroot="10.0.2.2:foo"
+#	bootparam_nbdport="10809"
+#	bootparam_root="/dev/nbd0"
+#	bootparam_ip="dhcp"
+#	ROOTFS_DIR="/rootfs"
+
+	echo "nbdroot=${bootparam_nbdroot}"
+	echo "ip=${bootparam_ip}"
+	echo "nbdport=${bootparam_nbdport}"
+
+	set -x
+	nbd_opts=""
+	if [ "${bootparam_nbdroot#*,}" != "${bootparam_nbdroot}" ]; then
+		nbd_opts="-o ${bootparam_nbdroot#*,}"
+	fi
+
+	location="${bootparam_nbdroot%%,*}"
+
+	# echo "<location#*:>= ${location#*:}"
+
+	if [ "${location#*:}" = "${location}" ]; then
+		# server-ip not given. Get server ip from ip option
+		if [ -z "$server_ip" ]; then
+			fatal "Server IP is not set. Update ip or nbdroot options."
+		fi
+	else
+		server_ip="${location%%:*}"
+		location="${location#*:}"
+	fi
+
+	# echo "location=${location}"
+	# echo "server_ip=${server_ip}"
+	# echo "nbd-client -name ${location} ${server_ip} ${bootparam_nbdport} ${bootparam_root}"
+	# echo "mount ${bootparam_root} ${ROOTFS_DIR}"
+
+	nbd-client -name ${location} ${server_ip} ${bootparam_nbdport} ${bootparam_root}
+	mount ${bootparam_root} ${ROOTFS_DIR}
+
+	set +x
+}

--- a/recipes-core/initrdscripts/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_1.0.bbappend
@@ -1,0 +1,21 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/initramfs-framework:"
+
+SRC_URI += " \
+           file://nbdrootfs \
+          "
+
+do_install:append() {
+
+    # base
+    install -m 0755 ${WORKDIR}/nbdrootfs ${D}/init.d/86-nbdrootfs
+}
+
+PACKAGES += " \
+            initramfs-module-nbdrootfs \
+           "
+
+
+SUMMARY:initramfs-module-nbdrootfs = "initramfs support for locating and mounting the root partition via nbd"
+RDEPENDS:initramfs-module-nbdrootfs = "${PN}-base"
+FILES:initramfs-module-nbdrootfs = "/init.d/86-nbdrootfs"
+

--- a/recipes-sifive/images/demo-coreip-cli-initramfs.bb
+++ b/recipes-sifive/images/demo-coreip-cli-initramfs.bb
@@ -1,0 +1,53 @@
+DESCRIPTION = "SiFive RISC-V Core IP Demo Benchmarks Linux image"
+
+RDEPENDS = "demo-coreip-cli"
+DEPENDS = "demo-coreip-cli"
+
+# IMAGE_FEATURES += "\
+#    nfs-client"
+
+# IMAGE_INSTALL = "\
+#    packagegroup-core-boot \
+#    nbd-client \
+#    "
+# inherit core-image extrausers
+
+# Simple initramfs image. Mostly used for live images.
+DESCRIPTION = "Small image capable of booting a device. The kernel includes \
+the Minimal RAM-based Initial Root Filesystem (initramfs), which finds the \
+first 'init' program more efficiently."
+
+INITRAMFS_SCRIPTS ?= "\
+		initramfs-framework-base \
+		initramfs-module-nfsrootfs \
+		initramfs-module-nbdrootfs \
+		initramfs-module-udev \
+		initramfs-module-e2fs \
+                "
+
+# PACKAGE_INSTALL = "${INITRAMFS_SCRIPTS} ${VIRTUAL-RUNTIME_base-utils} udev base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
+PACKAGE_INSTALL = "${INITRAMFS_SCRIPTS} busybox base-passwd udev nbd-client"
+
+IMAGE_FSTYPES = "cpio.gz"
+
+IMAGE_FEATURES += "\
+    nfs-client"
+
+IMAGE_INSTALL = "\
+    nbd-client \
+    "
+export IMAGE_BASENAME = "${MLPREFIX}demo-coreip-cli-initramfs"
+IMAGE_NAME_SUFFIX ?= ""
+IMAGE_LINGUAS = ""
+
+LICENSE = "MIT"
+
+# IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
+inherit core-image
+
+IMAGE_ROOTFS_SIZE = "8192"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+
+# Use the same restriction as initramfs-module-install
+# COMPATIBLE_HOST = '(x86_64.*|i.86.*|riscv64*|arm.*|aarch64.*)-(linux.*|freebsd.*)'
+COMPATIBLE_HOST = 'riscv64-oe-linux'


### PR DESCRIPTION
1. recipes-core/initrdscripts/initramfs-framework/nbdrootfs: add nbd boot script
2. recipes-core/initrdscripts/initramfs-framework_1.0.bbappend: install nbd boot script into initramfs framework
3. recipes-sifive/images/demo-coreip-cli-initramfs.bb: add new recipe to build image with initramfs

Signed-off-by: Max Hsu <max.hsu@sifive.com>