### PR TITLE
scripts: kas: update oe-core

### DIFF
--- a/scripts/kas/include/freedom-u-sdk-common.yml
+++ b/scripts/kas/include/freedom-u-sdk-common.yml
@@ -15,7 +15,7 @@ repos:
 
   openembedded-core:
     url: https://git.openembedded.org/openembedded-core
-    commit: 8519978592483bb096ed5192fff7af6c887b799e
+    commit: ab57471acad7ce2a037480dc7b301104620f1ebf
     layers:
       meta:
 


### PR DESCRIPTION
Update oe-core from yocto-5.3 to yocto-5.3.3.

This update fixes 'pseudo' on systems like "opensuseleap-16.0", where previously packages like "linux-libc-headers" would fail their "do_package" step.

Excerpt of the error log:

```
DEBUG: Executing python function perform_packagecopy
ERROR: Error executing a python function in exec_func_python() autogenerated:

The stack trace of python calls that resulted in this exception/failure was:
File: 'exec_func_python() autogenerated', lineno: 2, function: <module>
     0001:
 *** 0002:perform_packagecopy(d)
     0003:
File: '/home/remes/yocto/2026.01.00/build/../openembedded-core/meta/classes-global/package.bbclass', lineno: 365, function: perform_packagecopy
     0361:        rpath_replace (dvar, d)
     0362:}
     0363:perform_packagecopy[cleandirs] = "${PKGD}"
     0364:perform_packagecopy[dirs] = "${PKGD}"
 *** 0365:
     0366:python populate_packages () {
     0367:    oe.package.populate_packages(d)
     0368:}
     0369:populate_packages[dirs] = "${D}"
File: '/usr/lib64/python3.13/subprocess.py', lineno: 472, function: check_output
     0468:        else:
     0469:            empty = b''
     0470:        kwargs['input'] = empty
     0471:
 *** 0472:    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
     0473:               **kwargs).stdout
     0474:
     0475:
     0476:class CompletedProcess(object):
File: '/usr/lib64/python3.13/subprocess.py', lineno: 577, function: run
     0573:            # We don't call process.wait() as .__exit__ does that for us.
     0574:            raise
     0575:        retcode = process.poll()
     0576:        if check and retcode:
 *** 0577:            raise CalledProcessError(retcode, process.args,
     0578:                                     output=stdout, stderr=stderr)
     0579:    return CompletedProcess(process.args, retcode, stdout, stderr)
     0580:
     0581:
Exception: subprocess.CalledProcessError: Command 'tar --exclude=./sysroot-only -cf - -C /home/remes/yocto/2026.01.00/build/tmp/work/riscv64imafdc-freedomusdk-linux/linux-libc-headers/6.17/image -p -S . | tar -xf - -C /home/remes/yocto/2026.01.00/build/tmp/work/riscv64imafdc-freedomusdk-linux/linux-libc-headers/6.17/package' returned non-zero exit status 2.

Subprocess output:
got *at() syscall for unknown directory, fd 4
unknown base path for fd 4, path include
couldn't allocate absolute path for 'include'.
tar: ./usr/include: Cannot mkdir: Bad address
got *at() syscall for unknown directory, fd 4
unknown base path for fd 4, path include
couldn't allocate absolute path for 'include'.
```