### PR TITLE
conf: distro: freedom-u-sdk: enable fortran

### DIFF
--- a/conf/distro/freedom-u-sdk.conf
+++ b/conf/distro/freedom-u-sdk.conf
@@ -74,6 +74,8 @@ INIT_MANAGER ?= "${FREEDOM_INIT_MANAGER}"
 # Enable creation of SPDX manifests by default
 INHERIT += "create-spdx"
 
+FORTRAN = ",fortran"
+
 PREFERRED_PROVIDER_base-utils = "packagegroup-core-base-utils"
 VIRTUAL-RUNTIME_base-utils = "packagegroup-core-base-utils"
 VIRTUAL-RUNTIME_base-utils-hwclock = "util-linux-hwclock"


### PR DESCRIPTION
In a previous commit, the fortran assignment was entirely deleted, while it should have just been replaced by a regular assignment without 'forcevariable'. This breaks the build, because gfortran is needed in demo-coreip-cli.

Add fortran back to the distro.